### PR TITLE
Add limit option to history function to limit number of results in query

### DIFF
--- a/lib/repo/queryable.ex
+++ b/lib/repo/queryable.ex
@@ -24,6 +24,9 @@ defmodule ExAudit.Queryable do
         order_by: [desc: :recorded_at]
       )
 
+    limit = Keyword.get(opts, :limit)
+    query = if limit, do: query |> limit(^limit), else: query
+
     # TODO what do when we get a query
 
     query =

--- a/test/ex_audit_test.exs
+++ b/test/ex_audit_test.exs
@@ -68,6 +68,9 @@ defmodule ExAuditTest do
     versions = Repo.history(user)
 
     assert length(versions) == 3
+
+    latest = Repo.history(user, limit: 1)
+    assert length(latest) == 1
   end
 
   test "should track custom data" do


### PR DESCRIPTION
Like the description says, this just changes the `Repo.history` function to check for a `:limit` option and if present, uses that to limit the Version query.